### PR TITLE
remove rails12factor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,8 +90,6 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
-gem 'rails_12factor', group: :production
-
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -326,11 +326,6 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (6.0.4.1)
       actionpack (= 6.0.4.1)
       activesupport (= 6.0.4.1)
@@ -513,7 +508,6 @@ DEPENDENCIES
   rack-attack
   rails (~> 6.0)
   rails-controller-testing
-  rails_12factor
   react_on_rails (= 11.2.1)
   rearmed
   rspec

--- a/app/services/csv_create_service.rb
+++ b/app/services/csv_create_service.rb
@@ -1,5 +1,5 @@
 # Not currently used... not sure why
-class CSVCreateService
+class CsvCreateService
   def initialize(params)
     site = Site.find(params[:site_id])
     @submissions = site.submissions

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,7 @@ Bundler.require(*Rails.groups)
 module MonumentalServer
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.2
+    config.load_defaults 6.0
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/spec/controllers/admin/insta_upload_controller_spec.rb
+++ b/spec/controllers/admin/insta_upload_controller_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
-RSpec.describe Admin::InstaUploadController, type: :request do
+RSpec.describe InstaUploadController, type: :request do
   let(:headers)  { {"CONTENT_TYPE" => "application/json" }}
   let(:instamancer) { 'spec/fixtures/assets/monumentmonitor.json' }
   let(:params) {{  

--- a/spec/services/csv_create_service_spec.rb
+++ b/spec/services/csv_create_service_spec.rb
@@ -1,5 +1,5 @@
 require "rails_helper"
-RSpec.describe CSVCreateService do
+RSpec.describe CsvCreateService do
   let(:submission) { create(:submission) }
   let(:params) {{ site_id: submission.site_id }}
   let(:expected_csv) { "site_name,type_name,reliable,record_taken\nSome Stones,EMAIL,false,2019-04-26 00:00:00 UTC\n" }


### PR DESCRIPTION
Also - makes defaults 6.0. This was missed in last commit and the rails 7 disaster