### PR TITLE
adds validation to ensure images are attached at creation

### DIFF
--- a/app/jobs/csv_report_upload_job.rb
+++ b/app/jobs/csv_report_upload_job.rb
@@ -21,7 +21,7 @@ class CsvReportUploadJob
     
     if record_taken > @date
       unless Submission.find_by(id: id)
-        registration = Registration.new(
+        registration = ScriptRegistration.new(
           submission_id: id,
           reliable: false, 
           site_id: site_id, 
@@ -58,7 +58,7 @@ class CsvReportUploadJob
   end
 
   def get_image_url
-    if ENV['BASE_URL'].present?
+    if ENV['BASE_URL'].present? && Rails.env == 'production' || Rails.env == 'development'
       ENV['BASE_URL'] + @data_row['image_url'] 
     else
       Rails.root + @data_row['image_url'] 

--- a/app/jobs/twitter_job.rb
+++ b/app/jobs/twitter_job.rb
@@ -23,7 +23,7 @@ class TwitterJob
     record_taken = tweet.created_at
     image_url = media.media_url
 
-    registration = Registration.new(reliable: false, 
+    registration = ScriptRegistration.new(reliable: false, 
       site_id: site_id, 
       image_file: image_url, 
       comment: twitter_desc,

--- a/app/models/script_registration.rb
+++ b/app/models/script_registration.rb
@@ -1,0 +1,83 @@
+# The same as a registration - except for submissions uploaded via scripts with image URLs instead of attachements
+class ScriptRegistration
+  include ActiveModel::Model
+
+  attr_accessor :submission_id, :reliable, :site_id, :image, :image_file, :record_taken, :submitted_at, :type_name, :participant_id, :type_specific_id, :comment
+
+  def save
+    return false if invalid?
+    ActiveRecord::Base.transaction do
+      participant = find_or_create_participant(participant_id)
+      participant.update(first_submission: record_taken) if participant.first_submission.nil?
+
+      if submission_id.present?
+        submission = Submission.create(id: submission_id,
+          site_id: site_id,
+          participant_id: participant.id, 
+          reliable: reliable, 
+          record_taken: record_taken, 
+          submitted_at: submitted_at, 
+          type_name: type_name,
+          comment: comment,
+          type_specific_id: type_specific_id,
+          image: image)
+      else
+        submission = Submission.create(site_id: site_id,
+          participant_id: participant.id, 
+          reliable: reliable, 
+          record_taken: record_taken, 
+          submitted_at: submitted_at, 
+          type_name: type_name,
+          comment: comment,
+          type_specific_id: type_specific_id,
+          image: image)
+      end
+          
+      # For twitter and insta uploads, using image URL
+      save_image(submission, image_file, type_name) if image_file.present?
+          
+      # will blow up if invalid at this point
+      submission.save!
+      
+      # ensure filename is correct
+      submission.set_filename# unless image_file.present? 
+
+      submission
+    end
+    true
+  rescue ActiveRecord::RecordInvalid => e
+    # Handle exception that caused the transaction to fail
+    # e.message and e.cause.message can be helpful
+    errors.add(:base, e.message)
+    false
+  rescue Errno::ENOENT => e
+    errors.add(:base, e.message)
+    false
+  end
+
+  private
+
+  def save_image(submission, image_file, type_name)
+    begin
+      file = URI.open(image_file)
+      submission.image.attach(io: file, filename: "tmp-filename.jpg")
+    rescue OpenURI::HTTPError => e
+      puts "image is buggered"
+      errors.add(:base, e.message)
+      false
+    end
+  end
+
+  def find_or_create_participant(participant_id)
+    if participant_id.present?
+      anonymised_id = encrypt(participant_id)
+      Participant.find_or_create_by(participant_id: anonymised_id)
+    else
+      Participant.find_or_create_by(participant_id: Participant::DEFAULT_EMAIL)
+    end
+  end
+    
+  def encrypt(data)
+    Digest::SHA1.hexdigest data
+  end  
+end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -8,6 +8,7 @@ class Submission < ApplicationRecord
   validate :validate_site_id
   validate :validate_participant_id
   validates_presence_of :record_taken
+  validates :image, presence: true
 
   has_one_attached :image
   # to get url for image when developing API - use s.image.service_url

--- a/spec/models/script_registration_spec.rb
+++ b/spec/models/script_registration_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe ScriptRegistration, type: :model do
+  subject { described_class.new(params) }
+
+  let(:site) { create(:site) }
+  let(:email) { 'email@thing.com' }
+  let(:image) { Rails.root.join('spec', 'fixtures', 'assets', 'test-image.jpg') }
+  let(:date)  { Date.today }
+  let(:params) do
+    {
+      reliable: true,
+      site_id: site.id,
+      record_taken: date,
+      type_name: 'EMAIL',
+      participant_id: email,
+      image_file: image
+    }
+  end
+
+  describe '#save' do
+    context 'with correct parameters' do
+      it 'created successfully saves' do
+        expect(subject.save).to be true
+      end
+
+      it 'creates a new submission' do
+        expect { subject.save }.to change { Submission.count}.by(1)
+      end
+
+      it 'creates a new participant' do
+        expect { subject.save }.to change { Participant.count }.by(1)
+      end
+
+      it 'correctly assigned first_submission to participant' do
+        subject.save
+        expect(Participant.last.first_submission).to eq date
+      end
+
+      it 'correctly saves image filename' do
+        subject.save
+        submission = Submission.last
+        # binding.pry
+        expect(submission.image.attached?).to be true
+        file_name = "#{submission.id}_#{submission.record_taken.strftime('%d-%m-%Y')}_e.jpg"
+        expect(submission.image.attachment.filename.to_s).to eq file_name
+      end
+    end
+
+    context 'with no participant' do
+      let(:email) { '' }
+      it "assigns a defualt participant" do
+        id = Participant.new(participant_id: Participant::DEFAULT_EMAIL).annonymize_participant_id
+
+        subject.save
+        submission = Submission.last
+        expect(submission.participant.participant_id).to eq id
+      end
+    end
+
+    context 'with invalid file' do
+      let(:image) { Rack::Test::UploadedFile.new('./spec/fixtures/assets/archive_submissions.zip', '.zip') }
+
+      it 'does not create a submission' do
+        expect {subject.save}.to change {Submission.count}.by(1)
+      end
+    end
+
+    context 'with incorrect params' do
+      let(:date) { '' }
+      it 'does not create submission or type' do
+        expect(subject.save).to be false
+      end
+    end
+  end
+end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -7,19 +7,30 @@ RSpec.describe Submission, type: :model do
   end 
   
   context 'validations' do
-    subject { described_class.new(params) }
-    let(:params) { { site_id: 123, record_taken: Date.today }}
+    subject { described_class.new(correct_params) }
+    let(:participant)     { create(:participant) }
+    let(:participant_id)  { participant.id }
+    let(:site)            { create(:site) }
+    let(:site_id)         { site.id }
+    let(:record_taken)    { Date.today }
+    let(:image_url)       { Rack::Test::UploadedFile.new('./spec/fixtures/assets/test-image.jpg', 'image/png')}
     
-    context 'when site id invalid' do
+    let(:correct_params) {{ site_id: site_id, 
+                            participant_id: participant_id, 
+                            record_taken: record_taken,
+                            image: image_url }
+                          }
+    
+    context 'when site is invalid' do
+      let(:site_id) { 24 }
       it 'throws error' do
         expect(subject.valid?).to be false
         expect(subject.errors.messages[:site_id].to_sentence).to eq "site id is invalid"
       end
     end
     
-    context 'when participant id invalid' do
-      let(:site)    { create(:site) }
-      let(:params) { { site_id: site.id, record_taken: Date.today }}
+    context 'when participant is invalid' do
+      let(:participant_id)    { 24 }
       
       it 'throws error' do
         expect(subject.valid?).to be false
@@ -27,11 +38,16 @@ RSpec.describe Submission, type: :model do
       end
     end
 
-    context 'when site id and participant id valid' do
-      let(:site)   { create(:site) }
-      let(:participant) { create(:participant) }
-      let(:params) { { site_id: site.id, participant_id: participant.id, record_taken: Date.today }}
+    context "when image url is nil" do
+      let(:image_url) { nil }
 
+      it "throws an error" do
+        expect(subject.valid?).to be false
+        expect(subject.errors.messages[:image].to_sentence).to eq "can't be blank"
+      end
+    end
+
+    context 'when all params valid' do
       it 'creates submission' do
         expect(subject.valid?).to be true
       end


### PR DESCRIPTION
Adds validation to ensure images are attached
creates new model to create registrations when uploading from script
When uploading from script a URL for an image is given, not an attachment, so the submission needs to be created first